### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Some Github actions are not up-to-date (e.g. `actions/checkout@v2`). This PR adds dependabot to automatically propose updates for github-actions in the future.