### PR TITLE
file: refactored the file layer so it only implements business logic

### DIFF
--- a/deps/crc32/crc32.c
+++ b/deps/crc32/crc32.c
@@ -350,7 +350,7 @@ crc_t crc_update(crc_t crc, const void *data, size_t data_len)
     const uint32_t *d32 = (const uint32_t *)d;
     while (data_len >= 8)
     {
-#if __BYTE_ORDER == __BIG_ENDIAN
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
         crc_t d1 = *d32++ ^ le16toh(crc);
         crc_t d2 = *d32++;
         crc  =

--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -40,9 +40,8 @@ struct cio_file {
     char *path;               /* root path + stream   */
     char *map;                /* map of data          */
 #ifdef _WIN32
-    void *h;
-    crc_t crc_be;
-    int map_synced;
+    HANDLE backing_file;
+    HANDLE backing_mapping;
 #endif
     /* cached addr */
     char *st_content;
@@ -61,7 +60,7 @@ void cio_file_close(struct cio_chunk *ch, int delete);
 int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size);
 int cio_file_sync(struct cio_chunk *ch);
-int cio_file_fs_size_change(struct cio_file *cf, size_t new_size);
+int cio_file_resize(struct cio_file *cf, size_t new_size);
 char *cio_file_hash(struct cio_file *cf);
 void cio_file_hash_print(struct cio_file *cf);
 void cio_file_calculate_checksum(struct cio_file *cf, crc_t *out);
@@ -78,5 +77,8 @@ int cio_file_up_force(struct cio_chunk *ch);
 int cio_file_lookup_user(char *user, void **result);
 int cio_file_lookup_group(char *group, void **result);
 int cio_file_update_size(struct cio_file *cf);
+
+#define cio_file_report_runtime_error() { cio_file_native_report_runtime_error(); }
+#define cio_file_report_os_error() { cio_file_native_report_os_error(); }
 
 #endif

--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -77,5 +77,6 @@ int cio_file_up(struct cio_chunk *ch);
 int cio_file_up_force(struct cio_chunk *ch);
 int cio_file_lookup_user(char *user, void **result);
 int cio_file_lookup_group(char *group, void **result);
+int cio_file_update_size(struct cio_file *cf);
 
 #endif

--- a/include/chunkio/cio_file_native.h
+++ b/include/chunkio/cio_file_native.h
@@ -22,14 +22,32 @@
 
 #include <chunkio/cio_file.h>
 
+
+
+#ifdef _WIN32
+#define cio_file_native_is_open(cf) (cf->backing_file != INVALID_HANDLE_VALUE)
+#define cio_file_native_is_mapped(cf) (cf->backing_mapping != INVALID_HANDLE_VALUE)
+#define cio_file_native_report_runtime_error() { cio_errno(); }
+#define cio_file_native_report_os_error() { cio_winapi_error(); }
+#else
+#define cio_file_native_is_open(cf) (cf->fd != -1)
+#define cio_file_native_is_mapped(cf) (cf->map != NULL)
+#define cio_file_native_report_runtime_error() { cio_errno(); }
+#define cio_file_native_report_os_error() { cio_errno(); }
+#endif
+
+int cio_file_native_apply_acl_and_settings(struct cio_ctx *ctx, struct cio_file *cf);
+char *cio_file_native_compose_path(char *root_path, char *stream_name, 
+                                   char *chunk_name);
 int cio_file_native_unmap(struct cio_file *cf);
 int cio_file_native_map(struct cio_file *cf, size_t map_size);
 int cio_file_native_remap(struct cio_file *cf, size_t new_size);
 int cio_file_native_lookup_user(char *user, void **result);
 int cio_file_native_lookup_group(char *group, void **result);
 int cio_file_native_get_size(struct cio_file *cf, size_t *file_size);
-int cio_file_native_open(struct cio_ctx *ctx, struct cio_file *cf);
-void cio_file_native_close(struct cio_file *cf);
+int cio_file_native_filename_check(char *name);
+int cio_file_native_open(struct cio_file *cf);
+int cio_file_native_close(struct cio_file *cf);
 int cio_file_native_delete(struct cio_file *cf);
 int cio_file_native_sync(struct cio_file *cf, int sync_mode);
 int cio_file_native_resize(struct cio_file *cf, size_t new_size);

--- a/include/chunkio/cio_file_native.h
+++ b/include/chunkio/cio_file_native.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Chunk I/O
+ *  =========
+ *  Copyright 2018 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CIO_FILE_NATIVE_H
+#define CIO_FILE_NATIVE_H
+
+#include <chunkio/cio_file.h>
+
+int cio_file_native_unmap(struct cio_file *cf);
+int cio_file_native_map(struct cio_file *cf, size_t map_size);
+int cio_file_native_remap(struct cio_file *cf, size_t new_size);
+int cio_file_native_lookup_user(char *user, void **result);
+int cio_file_native_lookup_group(char *group, void **result);
+int cio_file_native_get_size(struct cio_file *cf, size_t *file_size);
+int cio_file_native_open(struct cio_ctx *ctx, struct cio_file *cf);
+void cio_file_native_close(struct cio_file *cf);
+int cio_file_native_delete(struct cio_file *cf);
+int cio_file_native_sync(struct cio_file *cf, int sync_mode);
+int cio_file_native_resize(struct cio_file *cf, size_t new_size);
+
+#endif

--- a/include/chunkio/cio_file_st.h
+++ b/include/chunkio/cio_file_st.h
@@ -75,8 +75,8 @@ static inline uint16_t cio_file_st_get_meta_len(char *map)
 /* Set metadata length */
 static inline void cio_file_st_set_meta_len(char *map, uint16_t len)
 {
-    map[22] = (uint8_t) len >> 8;
-    map[23] = (uint8_t) len;
+    map[22] = (uint8_t) (len >> 8);
+    map[23] = (uint8_t) (len & 0xFF);
 }
 
 /* Return pointer to start point of metadata */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(src
   cio_os.c
   cio_log.c
+  cio_file.c
   cio_memfs.c
   cio_chunk.c
   cio_meta.c
@@ -27,7 +28,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 else()
   set(src
     ${src}
-    cio_file.c
+    cio_file_unix.c
     )
 endif()
 

--- a/src/cio_file.c
+++ b/src/cio_file.c
@@ -1105,8 +1105,6 @@ int cio_file_resize(struct cio_file *cf, size_t new_size)
         result = cio_file_native_unmap(cf);
 
         if (result != CIO_OK) {
-            cio_file_native_report_error();
-
             return result;
         }
     }
@@ -1120,10 +1118,6 @@ int cio_file_resize(struct cio_file *cf, size_t new_size)
 #ifdef _WIN32
         if (mapped_flag) {
             inner_result = cio_file_native_map(cf, mapped_size);
-
-            if (inner_result != CIO_OK) {
-                cio_file_native_report_error();
-            }
         }
 #endif
 
@@ -1138,8 +1132,6 @@ int cio_file_resize(struct cio_file *cf, size_t new_size)
 #endif
 
         if (result != CIO_OK) {
-            cio_file_native_report_os_error();
-
             return result;
         }
     }

--- a/src/cio_file_unix.c
+++ b/src/cio_file_unix.c
@@ -1,0 +1,463 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Chunk I/O
+ *  =========
+ *  Copyright 2018-2019 Eduardo Silva <eduardo@monkey.io>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <limits.h>
+#include <pwd.h>
+#include <grp.h>
+
+#include <chunkio/chunkio.h>
+#include <chunkio/chunkio_compat.h>
+#include <chunkio/cio_crc32.h>
+#include <chunkio/cio_chunk.h>
+#include <chunkio/cio_file.h>
+#include <chunkio/cio_file_native.h>
+#include <chunkio/cio_file_st.h>
+#include <chunkio/cio_log.h>
+#include <chunkio/cio_stream.h>
+#include <chunkio/cio_error.h>
+#include <chunkio/cio_utils.h>
+
+
+int cio_file_native_unmap(struct cio_file *cf)
+{
+    int ret;
+
+    if (cf == NULL) {
+        return -1;
+    }
+
+    ret = munmap(cf->map, cf->alloc_size);
+
+    if (ret == 0)
+    {
+        cf->map = NULL;
+    }
+
+    return ret;
+}
+
+int cio_file_native_map(struct cio_file *cf, size_t map_size)
+{
+    int flags;
+
+    if (cf == NULL) {
+        return CIO_ERROR;
+    }
+
+    if (cf->map != NULL) {
+        return CIO_OK;
+    }
+
+    if (cf->flags & CIO_OPEN_RW) {
+        flags = PROT_READ | PROT_WRITE;
+    }
+    else if (cf->flags & CIO_OPEN_RD) {
+        flags = PROT_READ;
+    }
+    else {
+        flags = 0;
+    }
+
+    cf->map = mmap(0, map_size, flags, MAP_SHARED, cf->fd, 0);
+
+    if (cf->map == MAP_FAILED) {
+        cio_errno();
+
+        return CIO_ERROR;
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_remap(struct cio_file *cf, size_t new_size)
+{
+    int   result;
+    void *tmp;
+
+    result = 0;
+
+/* OSX mman does not implement mremap or MREMAP_MAYMOVE. */
+#ifndef MREMAP_MAYMOVE
+    result = cio_file_native_unmap(cf);
+
+    if (result == -1) {
+        return CIO_ERROR;
+    }
+
+    tmp = mmap(0, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, cf->fd, 0);
+#else
+    (void) result;
+
+    tmp = mremap(cf->map, cf->alloc_size, new_size, MREMAP_MAYMOVE);
+#endif
+
+    if (tmp == MAP_FAILED) {
+        return CIO_ERROR;
+    }
+
+    cf->map = tmp;
+    cf->alloc_size = new_size;
+
+    return CIO_OK;
+}
+
+int cio_file_native_lookup_user(char *user, void **result)
+{
+    long           query_buffer_size;
+    struct passwd *query_result;
+    char          *query_buffer;
+    struct passwd  passwd_entry;
+    int            api_result;
+
+    if (user == NULL) {
+        *result = calloc(1, sizeof(uid_t));
+
+        if (*result == NULL) {
+            cio_errno();
+
+            return CIO_ERROR;
+        }
+
+        **(uid_t **) result = (uid_t) -1;
+    }
+
+    query_buffer_size = sysconf(_SC_GETPW_R_SIZE_MAX);
+
+    if (query_buffer_size == -1) {
+        query_buffer_size = 4096 * 10;
+    }
+
+    query_buffer = calloc(1, query_buffer_size);
+
+    if (query_buffer == NULL) {
+        return CIO_ERROR;
+    }
+
+    query_result = NULL;
+
+    api_result = getpwnam_r(user, &passwd_entry, query_buffer,
+                            query_buffer_size, &query_result);
+
+    if (api_result != 0 || query_result == NULL) {
+        cio_errno();
+
+        free(query_buffer);
+
+        return CIO_ERROR;
+    }
+
+    *result = calloc(1, sizeof(uid_t));
+
+    if (*result == NULL) {
+        cio_errno();
+
+        free(query_buffer);
+
+        return CIO_ERROR;
+    }
+
+    **(uid_t **) result = query_result->pw_uid;
+
+    free(query_buffer);
+
+    return CIO_OK;
+}
+
+int cio_file_native_lookup_group(char *group, void **result)
+{
+    long           query_buffer_size;
+    struct group  *query_result;
+    char          *query_buffer;
+    struct group   group_entry;
+    int            api_result;
+
+    if (group == NULL) {
+        *result = calloc(1, sizeof(gid_t));
+
+        if (*result == NULL) {
+            cio_errno();
+
+            return CIO_ERROR;
+        }
+
+        **(gid_t **) result = (gid_t) -1;
+    }
+
+    query_buffer_size = sysconf(_SC_GETGR_R_SIZE_MAX);
+
+    if (query_buffer_size == -1) {
+        query_buffer_size = 4096 * 10;
+    }
+
+    query_buffer = calloc(1, query_buffer_size);
+
+    if (query_buffer == NULL) {
+        return CIO_ERROR;
+    }
+
+    query_result = NULL;
+
+    api_result = getgrnam_r(group, &group_entry, query_buffer,
+                            query_buffer_size, &query_result);
+
+    if (api_result != 0 || query_result == NULL) {
+        cio_errno();
+
+        free(query_buffer);
+
+        return CIO_ERROR;
+    }
+
+    *result = calloc(1, sizeof(gid_t));
+
+    if (*result == NULL) {
+        cio_errno();
+
+        free(query_buffer);
+
+        return CIO_ERROR;
+    }
+
+    **(gid_t **) result = query_result->gr_gid;
+
+    free(query_buffer);
+
+    return CIO_OK;
+}
+
+static int apply_file_ownership_and_acl_settings(struct cio_ctx *ctx, char *path)
+{
+    mode_t filesystem_acl;
+    gid_t  numeric_group;
+    uid_t  numeric_user;
+    char  *connector;
+    int    result;
+    char  *group;
+    char  *user;
+
+    numeric_group = -1;
+    numeric_user = -1;
+
+    if (ctx->processed_user != NULL) {
+        numeric_user = *(uid_t *) ctx->processed_user;
+    }
+
+    if (ctx->processed_group != NULL) {
+        numeric_group = *(gid_t *) ctx->processed_group;
+    }
+
+    if (numeric_user != -1 || numeric_group != -1) {
+        result = chown(path, numeric_user, numeric_group);
+
+        if (result == -1) {
+            cio_errno();
+
+            user = ctx->options.user;
+            group = ctx->options.group;
+            connector = "with group";
+
+            if (user == NULL) {
+                user = "";
+                connector = "";
+            }
+
+            if (group == NULL) {
+                group = "";
+                connector = "";
+            }
+
+            cio_log_error(ctx, "cannot change ownership of %s to %s %s %s",
+                          path, user, connector, group);
+
+            return CIO_ERROR;
+        }
+    }
+
+    if (ctx->options.chmod != NULL) {
+        filesystem_acl = strtoul(ctx->options.chmod, NULL, 8);
+
+        result = chmod(path, filesystem_acl);
+
+        if (result == -1) {
+            cio_errno();
+            cio_log_error(ctx, "cannot change acl of %s to %s",
+                          path, ctx->options.user);
+
+            return CIO_ERROR;
+        }
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_get_size(struct cio_file *cf, size_t *file_size)
+{
+    int         ret;
+    struct stat st;
+
+    ret = -1;
+
+    if (cf->fd != -1) {
+        ret = fstat(cf->fd, &st);
+    }
+
+    if (ret == -1) {
+        ret = stat(cf->path, &st);
+    }
+
+    if (ret == -1) {
+        return CIO_ERROR;
+    }
+
+    if (file_size != NULL) {
+        *file_size = st.st_size;
+    }
+
+    return CIO_OK;
+}
+
+/* Open file system file, set file descriptor and file size */
+int cio_file_native_open(struct cio_ctx *ctx, struct cio_file *cf)
+{
+    int    ret;
+
+    if (cf->map != NULL || cf->fd != -1) {
+        return -1;
+    }
+
+    /* Open file descriptor */
+    if (cf->flags & CIO_OPEN_RW) {
+        cf->fd = open(cf->path, O_RDWR | O_CREAT, (mode_t) 0600);
+    }
+    else if (cf->flags & CIO_OPEN_RD) {
+        cf->fd = open(cf->path, O_RDONLY);
+    }
+
+    if (cf->fd == -1) {
+        cio_errno();
+        cio_log_error(ctx, "cannot open/create %s", cf->path);
+
+        return -1;
+    }
+
+    ret = apply_file_ownership_and_acl_settings(ctx, cf->path);
+
+    if (ret == CIO_ERROR) {
+        cio_errno();
+        cio_file_native_close(cf);
+
+        return -1;
+    }
+
+    ret = cio_file_update_size(cf);
+
+    if (ret != CIO_OK) {
+        cio_file_native_close(cf);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+void cio_file_native_close(struct cio_file *cf)
+{
+    if (cf != NULL && cf->fd != 0) {
+        close(cf->fd);
+
+        cf->fd = -1;
+    }
+}
+
+int cio_file_native_delete(struct cio_file *cf)
+{
+    return unlink(cf->path);
+}
+
+int cio_file_native_sync(struct cio_file *cf, int sync_mode)
+{
+    int result;
+
+    result = msync(cf->map, cf->alloc_size, sync_mode);
+
+    if (result == -1) {
+        return CIO_ERROR;
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_resize(struct cio_file *cf, size_t new_size)
+{
+    int ret = -1;
+
+    /*
+     * fallocate() is not portable an Linux only. Since macOS does not have
+     * fallocate() we use ftruncate().
+     */
+#if defined(CIO_HAVE_FALLOCATE)
+    if (new_size > cf->alloc_size) {
+        retry:
+
+        if (cf->allocate_strategy == CIO_FILE_LINUX_FALLOCATE) {
+            /*
+             * To increase the file size we use fallocate() since this option
+             * will send a proper ENOSPC error if the file system ran out of
+             * space. ftruncate() will not fail and upon memcpy() over the
+             * mmap area it will trigger a 'Bus Error' crashing the program.
+             *
+             * fallocate() is not portable, Linux only.
+             */
+            ret = fallocate(cf->fd, 0, 0, new_size);
+            if (ret == -1 && errno == EOPNOTSUPP) {
+                /*
+                 * If fallocate fails with an EOPNOTSUPP try operation using
+                 * posix_fallocate. Required since some filesystems do not support
+                 * the fallocate operation e.g. ext3 and reiserfs.
+                 */
+                cf->allocate_strategy = CIO_FILE_LINUX_POSIX_FALLOCATE;
+                goto retry;
+            }
+        }
+        else if (cf->allocate_strategy == CIO_FILE_LINUX_POSIX_FALLOCATE) {
+            ret = posix_fallocate(cf->fd, 0, new_size);
+        }
+    }
+    else
+#endif
+    {
+        ret = ftruncate(cf->fd, new_size);
+    }
+
+    if (!ret) {
+        cf->fs_size = new_size;
+    }
+
+    return ret;
+}

--- a/src/cio_file_win32.c
+++ b/src/cio_file_win32.c
@@ -25,800 +25,114 @@
 #include <chunkio/cio_crc32.h>
 #include <chunkio/cio_chunk.h>
 #include <chunkio/cio_file.h>
+#include <chunkio/cio_file_native.h>
 #include <chunkio/cio_file_st.h>
 #include <chunkio/cio_log.h>
 #include <chunkio/cio_stream.h>
 
-/*
- * Implement file chunk API for Windows.
- *
- * * This module uses "files" as shared buffers in lieu of mmap(2).
- *
- * * Every chunk operation is done directly to the underlying file
- *   through ReadFile/WriteFile API.
- *
- * * In this module, cf->map is a plain buffer allocated by malloc.
- *   cio_file_read_prepare() is in charge of keeping its content
- *   in sync with the underlying file.
- *
- * NOTE: there is a shared memory API named CreateFileMapping(),
- * but it's not usable in this module.
- *
- * The reason is that a file mapping prevents file resizes. Since
- * there can be several cio_file instances on the same file (see
- * cio_scan_stream_files() in cio_scan.c), it ends up preventing
- * everyone from resizing that file.
- */
-
-#define win32_chunk_error(ch, msg) \
-        cio_log_error((ch)->ctx, "%s on '%s/%s' (%s() line=%i)", \
-                      (msg), (ch)->st->name, (ch)->name, __func__, __LINE__)
-
-static char init_bytes[] = {
-    /* file type (2 bytes)    */
-    CIO_FILE_ID_00, CIO_FILE_ID_01,
-
-    /* crc32 (4 bytes) in network byte order */
-    0x41, 0xd9, 0x12, 0xff,
-
-    /* padding bytes (we have 16 extra bytes */
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00,
-
-    /* metadata length (2 bytes) */
-    0x00, 0x00
-};
-
-/*
- * Read N bytes from file. Return 0 on success, and -1 on
- * failure (including a partial read).
- */
-static int read_file(HANDLE h, char *buf, uint64_t size)
+int cio_file_native_unmap(struct cio_file *cf)
 {
-    uint64_t read = 0;
-    DWORD len;
-    DWORD bytes;
+    int result;
 
-    while (read < size) {
-        len = (int) min(size - read, 65536);
-        if (!ReadFile(h, buf + read, len, &bytes, NULL)) {
-            cio_winapi_error();
-            return -1;
-        }
-        if (bytes == 0) {
-            cio_winapi_error();
-            return -1;  /* EOF */
-        }
-        read += bytes;
-    }
-    return 0;
-}
-
-static int write_file(HANDLE h, const char *buf, uint64_t size)
-{
-    uint64_t written = 0;
-    DWORD len;
-    DWORD bytes;
-
-    while (written < size) {
-        len = (int) min(size - written, 65536);
-        if (!WriteFile(h, buf + written, len, &bytes, NULL)) {
-            cio_winapi_error();
-            return -1;
-        }
-        written += bytes;
-    }
-    return 0;
-}
-
-static int seek_file(HANDLE h, int64_t offset)
-{
-    LARGE_INTEGER liDistanceToMove;
-
-    liDistanceToMove.QuadPart = offset;
-
-    if (!SetFilePointerEx(h, liDistanceToMove, NULL, FILE_BEGIN)) {
-        cio_winapi_error();
-        return -1;
-    }
-    return 0;
-}
-
-static int64_t get_file_size(HANDLE h)
-{
-    LARGE_INTEGER liFileSize;
-
-    if (!GetFileSizeEx(h, &liFileSize)) {
-        cio_winapi_error();
-        return -1;
-    };
-    return liFileSize.QuadPart;
-}
-
-/*
- * Create an empty file chunk. This function erases all
- * the data inside the given chunk.
- */
-static int init_chunk(struct cio_chunk *ch)
-{
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-
-    if (seek_file(cf->h, 0)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        return -1;
-    }
-
-    if (write_file(cf->h, init_bytes, sizeof(init_bytes))) {
-        win32_chunk_error(ch, "[cio file] cannot write data");
-        return -1;
-    }
-
-    if (!SetEndOfFile(cf->h)) {
-        cio_winapi_error();
-        return -1;
-    }
-
-    cf->fs_size = sizeof(init_bytes);
-    cf->data_size = 0;
-    return 0;
-}
-
-/*
- * Read the meta size field in file. Return an integer between
- * [0, 0xffff] on success, and -1 on failure.
- */
-static int read_meta_size(struct cio_chunk *ch)
-{
-    uint16_t meta_size_be;
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-
-    if (seek_file(cf->h, CIO_FILE_CONTENT_OFFSET)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        return -1;
-    }
-
-    if (read_file(cf->h, (char *) &meta_size_be, 2)) {
-        win32_chunk_error(ch, "[cio file] cannot read meta size");
-        return -1;
-    }
-
-    return _byteswap_ushort(meta_size_be);
-}
-
-/*
- * Compute CRC32 checksum by scanning through the file.
- * Return 0 on success, and -1 on error.
- */
-static int calc_checksum(struct cio_file *cf, crc_t *out)
-{
-    char buf[1024];
-    int len;
-    crc_t val = cio_crc32_init();
-    uint64_t read = 0;
-    uint64_t size = 0;
-
-    if (seek_file(cf->h, CIO_FILE_CONTENT_OFFSET)) {
-        return -1;
-    }
-
-    size = cf->fs_size - CIO_FILE_CONTENT_OFFSET;
-
-    while (read < size) {
-        len = (int) min(size - read, 1024);
-        if (read_file(cf->h, buf, len)) {
-            return -1;
-        }
-        val = cio_crc32_update(val, buf, len);
-        read += len;
-    }
-    *out = cio_crc32_finalize(val);
-    return 0;
-}
-
-/*
- * Compute CRC32 and compare it against the checksum stored
- * in the file. Return 0 on success, -3 on content corruption
- * and -1 on error.
- */
-static int verify_checksum(struct cio_chunk *ch)
-{
-    crc_t hash;
-    crc_t hash_be;
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-
-    if (calc_checksum(cf, &hash)) {
-        win32_chunk_error(ch, "[cio file] cannot compute checksum");
+    if (cf == NULL) {
         return CIO_ERROR;
     }
 
-    if (seek_file(cf->h, 2)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
+    if (!cio_file_native_is_open(cf)) {
+        return CIO_OK;
+    }
+
+    if (!cio_file_native_is_mapped(cf)) {
+        return CIO_OK;
+    }
+
+    result = UnmapViewOfFile(cf->map);
+
+    if (result == 0) {
+        cio_file_native_report_os_error();
+
         return CIO_ERROR;
     }
 
-    /*
-     * cio_file.c stores CRC32 in big endian order and Windows
-     * is a little endian.
-     */
-    if (read_file(cf->h, (char *) &hash_be, 4)) {
-        win32_chunk_error(ch, "[cio file] cannot read hash");
-        return CIO_ERROR;
-    }
+    CloseHandle(cf->backing_mapping);
 
-    if (hash != (crc_t) _byteswap_ulong(hash_be)) {
-        cio_log_error(ch->ctx, "[cio file] hash does not match (%u != %u)",
-                      hash, _byteswap_ulong(hash_be));
-        return CIO_CORRUPTED;
-    }
+    cf->backing_mapping = INVALID_HANDLE_VALUE;
+    cf->alloc_size = 0;
+    cf->map = NULL;
 
     return CIO_OK;
 }
 
-/*
- * Return the number of active file chunks. This function is used
- * to check "max_chunks_up" limit.
- */
-static int count_open_file_chunks(struct cio_ctx *ctx)
+int cio_file_native_map(struct cio_file *cf, size_t map_size)
 {
-    int total = 0;
-    struct mk_list *head;
-    struct mk_list *f_head;
-    struct cio_file *file;
-    struct cio_chunk *ch;
-    struct cio_stream *stream;
+    DWORD desired_protection;
+    DWORD desired_access;
 
-    mk_list_foreach(head, &ctx->streams) {
-        stream = mk_list_entry(head, struct cio_stream, _head);
-
-        if (stream->type == CIO_STORE_MEM) {
-            continue;
-        }
-
-        mk_list_foreach(f_head, &stream->chunks) {
-            ch = mk_list_entry(f_head, struct cio_chunk, _head);
-            file = (struct cio_file *) ch->backend;
-
-            if (cio_file_is_up(NULL, file) == CIO_TRUE) {
-                total++;
-            }
-        }
+    if (cf == NULL) {
+        return CIO_ERROR;
     }
-    return total;
+
+    if (!cio_file_native_is_open(cf)) {
+        return CIO_ERROR;
+    }
+
+    if (cio_file_native_is_mapped(cf)) {
+        return CIO_OK;
+    }
+
+    if (cf->flags & CIO_OPEN_RW) {
+        desired_protection = PAGE_READWRITE;
+        desired_access = FILE_MAP_ALL_ACCESS;
+    }
+    else if (cf->flags & CIO_OPEN_RD) {
+        desired_protection = PAGE_READONLY;
+        desired_access = FILE_MAP_READ;
+    }
+    else {
+        return CIO_ERROR;
+    }
+
+    cf->backing_mapping = CreateFileMappingA(cf->backing_file, NULL,
+                                             desired_protection,
+                                             0, 0, NULL);
+
+    if (cf->backing_mapping == NULL) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    cf->map = MapViewOfFile(cf->backing_mapping, desired_access, 0, 0, map_size);
+
+    if (cf->map == NULL) {
+        cio_file_native_report_os_error();
+
+        CloseHandle(cf->backing_mapping);
+
+        cf->backing_mapping = INVALID_HANDLE_VALUE;
+
+        return CIO_ERROR;
+    }
+
+    cf->alloc_size = map_size;
+
+    return CIO_OK;
 }
 
-static char *create_path(struct cio_chunk *ch)
+int cio_file_native_remap(struct cio_file *cf, size_t new_size)
 {
-    char *path;
-    size_t len;
-    int ret;
-
-    len = strlen(ch->ctx->options.root_path) + strlen(ch->st->name) + strlen(ch->name);
-    len += 3;
-
-    path = calloc(1, len);
-    if (!path) {
-        cio_errno();
-        return NULL;
-    }
-
-    ret = sprintf_s(path, len, "%s\\%s\\%s",
-                    ch->ctx->options.root_path, ch->st->name, ch->name);
-    if (ret < 0) {
-        cio_errno();
-        free(path);
-        return NULL;
-    }
-    return path;
-}
-
-static int is_valid_file_name(const char *name)
-{
-    size_t len;
-
-    len = strlen(name);
-    if (len == 0) {
-        return 0;
-    }
-    else if (len == 1) {
-        if (name[0] == '\\' || name[0] == '.' || name[0] == '/') {
-            return 0;
-        }
-    }
-    return 1;
-}
-
-/*
- * Fetch the file size regardless of if we opened this file or not.
- */
-size_t cio_file_real_size(struct cio_file *cf)
-{
-    int ret;
-#ifdef _WIN64
-    struct _stat64 st;
-#else
-    struct _stat32 st;
-#endif
-
-    /* Store the current real size */
-#ifdef _WIN64
-    ret = _stat64(cf->path, &st);
-#else
-    ret = _stat32(cf->path, &st);
-#endif
-
-    if (ret != 0) {
-        cio_errno();
-        return 0;
-    }
-
-    return st.st_size;
-}
-
-/*
- * Return a new file chunk instance. This is the starting
- * point for manipulating file chunks.
- */
-struct cio_file *cio_file_open(struct cio_ctx *ctx,
-                               struct cio_stream *st,
-                               struct cio_chunk *ch,
-                               int flags,
-                               size_t size,
-                               int *err)
-{
-    struct cio_file *cf;
-
-    if (!is_valid_file_name(ch->name)) {
-        win32_chunk_error(ch, "[cio file] invalid file name");
-        return NULL;
-    }
-
-    cf = calloc(1, sizeof(struct cio_file));
-    if (!cf) {
-        cio_errno();
-        return NULL;
-    }
-
-    cf->path = create_path(ch);
-    if (cf->path == NULL) {
-        win32_chunk_error(ch, "[cio file] cannot create path");
-        free(cf);
-        return NULL;
-    }
-
-    cf->fd = -1;
-    cf->flags = flags;
-    cf->realloc_size = 0;
-    cf->st_content = NULL;
-    cf->crc_cur = 0;
-    cf->map = NULL;
-    cf->h = INVALID_HANDLE_VALUE;
-    ch->backend = cf;
-
-    if (count_open_file_chunks(ch->ctx) >= ctx->max_chunks_up) {
-        cio_log_debug(ch->ctx, "[cio file] create a chunk %s/%s (down)",
-                      st->name, ch->name);
-        return cf;  /* this is how cio_file.c behaves */
-    }
-
-    if (cio_file_up(ch)) {
-        win32_chunk_error(ch, "[cio file] cannot activate chunk");
-        cio_file_close(ch, CIO_FALSE);
-        return NULL;
-    }
-
-    if (ch->ctx->options.flags & CIO_CHECKSUM) {
-        if (verify_checksum(ch)) {
-            win32_chunk_error(ch, "[cio file] cannot verify checksum");
-            cio_file_close(ch, CIO_FALSE);
-            return NULL;
-        }
-    }
-
-    return cf;
-}
-
-/*
- * Deallocate a file chunk instance.
- */
-void cio_file_close(struct cio_chunk *ch, int delete)
-{
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-
-    if (!cf) {
-        return;
-    }
-
-    if (cio_file_is_up(ch, ch->backend)) {
-        cio_file_down(ch);
-    }
-
-    if (delete == CIO_TRUE) {
-        if (!DeleteFileA(cf->path)) {
-            cio_winapi_error();
-        }
-    }
-    free(cf->map);
-    free(cf->path);
-    free(cf);
-}
-
-/*
- * Append data into the end of the file chunk.
- */
-int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count)
-{
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-    int meta_size;
-
-    if (count == 0) {
-        return 0;
-    }
-
-    if (!cio_file_is_up(ch, ch->backend)) {
-        win32_chunk_error(ch, "[cio file] chunk is not up");
-        return -1;
-    }
-
-    meta_size = read_meta_size(ch);
-    if (meta_size < 0) {
-        win32_chunk_error(ch, "[cio file] cannot read meta size");
-        return -1;
-    }
-
-    if (seek_file(cf->h, CIO_FILE_HEADER_MIN + meta_size + cf->data_size)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        return -1;
-    }
-
-    if (write_file(cf->h, buf, count)) {
-        win32_chunk_error(ch, "[cio file] cannot write data");
-        return -1;
-    }
-
-    if (!SetEndOfFile(cf->h)) {
-        cio_winapi_error();
-        return -1;
-    }
-
-    cf->data_size += count;
-    cf->fs_size = CIO_FILE_HEADER_MIN + meta_size + cf->data_size;
-    cf->synced = CIO_FALSE;
-    cf->map_synced = CIO_FALSE;
-
-    return 0;
-}
-
-int create_space_for_meta(struct cio_chunk *ch, uint16_t meta_size)
-{
-    uint16_t prev_size;
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-    char *buf;
-    char *ptr;
-
-    if (cf->data_size == 0) {
-        return 0;  /* No need for relocation */
-    }
-
-    buf = malloc(cf->fs_size);
-    if (buf == NULL) {
-        cio_errno();
-        return -1;
-    }
-
-    if (seek_file(cf->h, 0)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        free(buf);
-        return -1;
-    }
-
-    if (read_file(cf->h, buf, cf->fs_size)) {
-        win32_chunk_error(ch, "[cio file] cannot read data");
-        free(buf);
-        return -1;
-    }
-
-    ptr = cio_file_st_get_content(buf);
-    prev_size = cio_file_st_get_meta_len(buf);
-
-    if (prev_size == meta_size) {
-        free(buf);
-        return 0;  /* nothing to do */
-    }
-
-    if (seek_file(cf->h, CIO_FILE_HEADER_MIN + meta_size)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        free(buf);
-        return -1;
-    }
-
-    if (write_file(cf->h, ptr, cf->data_size)) {
-        win32_chunk_error(ch, "[cio file] cannot write data");
-        free(buf);
-        return -1;
-    }
-    free(buf);
-
-    cf->fs_size = CIO_FILE_HEADER_MIN + meta_size + cf->data_size;
-
-    return 0;
-}
-
-int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size)
-{
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-    uint16_t meta_size = (uint16_t) size;
-    uint16_t meta_size_be = _byteswap_ushort(meta_size);
-
-    if (!cio_file_is_up(ch, cf)) {
-        win32_chunk_error(ch, "[cio file] chunk is not up");
-        return -1;
-    }
-
-    if (size > UINT16_MAX) {
-        cio_log_error(ch->ctx, "[cio file] too large meta (%zu bytes) %s:%s",
-                      size, ch->st->name, ch->name);
-        return -1;
-    }
-
-    if (create_space_for_meta(ch, meta_size)) {
-        cio_log_error(ch->ctx, "[cio file] fail to allocate %zu bytes %s:%s",
-                      size, ch->st->name, ch->name);
-        return -1;
-    }
-
-    if (seek_file(cf->h, CIO_FILE_CONTENT_OFFSET)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        return -1;
-    }
-
-    if (write_file(cf->h, (char *) &meta_size_be, 2)) {
-        win32_chunk_error(ch, "[cio file] cannot write meta size");
-        return -1;
-    }
-
-    if (write_file(cf->h, buf, meta_size)) {
-        win32_chunk_error(ch, "[cio file] cannot write meta data");
-        return -1;
-    }
-    cf->synced = CIO_FALSE;
-    cf->map_synced = CIO_FALSE;
-
-    return 0;
-}
-
-int cio_file_sync(struct cio_chunk *ch)
-{
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-    crc_t hash, hash_be;
-
-    if (calc_checksum(cf, &hash)) {
-        win32_chunk_error(ch, "[cio file] cannot compute checksum");
-        return -1;
-    }
-
-    if (cf->flags & CIO_OPEN_RD) {
-        cio_log_debug(ch->ctx, "[cio file] chunk '%s:%s' is read only",
-                      ch->st->name, ch->name);
-        return 0;
-    }
-
-    /* Windows is little endian */
-    hash_be = _byteswap_ulong(hash);
-
-    if (seek_file(cf->h, 2)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        return -1;
-    }
-
-    if (write_file(cf->h, (char *) &hash_be, 4)) {
-        win32_chunk_error(ch, "[cio file] cannot write hash");
-        return -1;
-    }
-
-    if (!FlushFileBuffers(cf->h)) {
-        cio_winapi_error();
-        return -1;
-    }
-
-    /* Reflect checksum to keep map synced */
-    if (cf->map) {
-        memcpy(cf->map + 2, &hash_be, 4);
-    }
-
-    cf->crc_be = hash_be;
-    cf->synced = CIO_TRUE;
-
-    cio_log_debug(ch->ctx, "[cio file] synced at: %s/%s",
-                  ch->st->name, ch->name);
-    return 0;
-}
-
-int cio_file_fs_size_change(struct cio_file *cf, size_t new_size)
-{
-    if (seek_file(cf->h, new_size)) {
-        return -1;
-    }
-
-    if (!SetEndOfFile(cf->h)) {
-        cio_winapi_error();
-        return -1;
-    }
-
-    cf->data_size += (cf->fs_size - new_size);
-    cf->fs_size = new_size;
-    return 0;
-}
-
-/*
- * Return the char pointer to the CRC32 field (big endian).
- */
-char *cio_file_hash(struct cio_file *cf)
-{
-    return (char *) &cf->crc_be;
-}
-
-void cio_file_hash_print(struct cio_file *cf)
-{
-    crc_t hash;
-
-    if (calc_checksum(cf, &hash)) {
-        printf("failed to compute hash");
-        return;
-    }
-
-    printf("crc =%u\n", hash);
-    printf("%08x\n", hash);
-}
-
-void cio_file_calculate_checksum(struct cio_file *cf, crc_t *out)
-{
-    calc_checksum(cf, out);
-}
-
-void cio_file_scan_dump(struct cio_ctx *ctx, struct cio_stream *st)
-{
-    (void *) ctx;
-    (void *) st;
-    return;
-}
-
-/*
- * Copy the file content into memory buffer so that the caller
- * can access the chunk data.
- */
-int cio_file_read_prepare(struct cio_ctx *ctx, struct cio_chunk *ch)
-{
-    (void *) ctx;
-    char *buf;
-    struct cio_file *cf = ch->backend;
-    int64_t size;
-
-    if (cf->map && cf->map_synced == CIO_TRUE) {
-        return 0;  /* no need to update */
-    }
-
-    size = get_file_size(cf->h);
-    if (size <= 0) {
-        win32_chunk_error(ch, "[cio file] cannot get file size");
-        return -1;
-    }
-
-    buf = malloc(size);
-    if (buf == NULL) {
-        cio_errno();
-        return -1;
-    }
-
-    if (seek_file(cf->h, 0)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        free(buf);
-        return -1;
-    }
-
-    if (read_file(cf->h, buf, size)) {
-        win32_chunk_error(ch, "[cio file] cannot read data");
-        free(buf);
-        return -1;
-    }
-
-    free(cf->map);
-    cf->map = buf;
-    cf->map_synced = CIO_TRUE;
-    return 0;
-}
-
-int cio_file_content_copy(struct cio_chunk *ch,
-                          void **out_buf, size_t *out_size)
-{
-    char *buf;
-    int ret = -1;
-    int meta_size;
-    int set_down = CIO_FALSE;
-    struct cio_file *cf = ch->backend;
-
-    if (cio_chunk_is_up(ch) == CIO_FALSE) {
-        ret = cio_chunk_up_force(ch);
-        if (ret == -1){
-            win32_chunk_error(ch, "[cio file] cannot activate chunk");
-            return ret;
-        }
-        set_down = CIO_TRUE;
-    }
-
-    meta_size = read_meta_size(ch);
-    if (meta_size < 0) {
-        win32_chunk_error(ch, "[cio file] cannot read meta size");
-        goto done;
-    }
-
-    buf = calloc(1, cf->data_size + 1);
-    if (buf == NULL) {
-        cio_errno();
-        goto done;
-    }
-
-    if (seek_file(cf->h, CIO_FILE_HEADER_MIN + meta_size)) {
-        win32_chunk_error(ch, "[cio file] cannot seek");
-        free(buf);
-        goto done;
-    }
-
-    if (read_file(cf->h, buf, cf->data_size)) {
-        win32_chunk_error(ch, "[cio file] cannot read data");
-        free(buf);
-        goto done;
-    }
-
-    *out_buf = buf;
-    *out_size = cf->data_size;
-    ret = 0;
-
-done:
-    if (set_down == CIO_TRUE) {
-        cio_chunk_down(ch);
-    }
-    return ret;
-}
-
-int cio_file_is_up(struct cio_chunk *ch, struct cio_file *cf)
-{
-    (void) ch;
-
-    if (cf->h != INVALID_HANDLE_VALUE) {
-        return CIO_TRUE;
-    }
-
-    return CIO_FALSE;
-}
-
-int cio_file_down(struct cio_chunk *ch)
-{
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-
-    if (!cio_file_is_up(ch, cf)) {
-        win32_chunk_error(ch, "[cio file] chunk is not up");
-        return -1;
-    }
-
-    CloseHandle(cf->h);
-    cf->h = INVALID_HANDLE_VALUE;
-    return 0;
-}
-
-int cio_file_up(struct cio_chunk *ch)
-{
-    if (cio_file_is_up(ch, ch->backend)) {
-        win32_chunk_error(ch, "[cio file] chunk is already up");
-        return -1;
-    }
-
-    if (count_open_file_chunks(ch->ctx) >= ch->ctx->max_chunks_up) {
-        win32_chunk_error(ch, "[cio file] too many open chunks");
-        return -1;
-    }
-    return cio_file_up_force(ch);
+    /*
+     * There's no reason for this function to exist because in windows
+     * we need to unmap, resize and then map again so there's no benefit
+     * from remapping and I'm not implementing a dummy version because I
+     * don't want anyone to read it and think there are any reasonable use
+     * cases for it.
+     */
+
+    (void) cf;
+    (void) new_size;
+
+    return CIO_ERROR;
 }
 
 static SID *perform_sid_lookup(char *account_name, SID_NAME_USE *result_sid_type)
@@ -838,12 +152,13 @@ static SID *perform_sid_lookup(char *account_name, SID_NAME_USE *result_sid_type
     sid_buffer = calloc(1, sid_buffer_size);
 
     if (sid_buffer == NULL) {
-        cio_winapi_error();
+        cio_file_native_report_runtime_error();
 
         return NULL;
     }
 
     result = 0;
+    sid_type = SidTypeUnknown;
 
     for (retry_index = 0 ; retry_index < 5 && !result ; retry_index++) {
         result = LookupAccountNameA(NULL,
@@ -861,14 +176,16 @@ static SID *perform_sid_lookup(char *account_name, SID_NAME_USE *result_sid_type
                 reallocated_sid_buffer = realloc(sid_buffer, sid_buffer_size);
 
                 if (reallocated_sid_buffer == NULL) {
-                    cio_winapi_error();
+                    cio_file_native_report_runtime_error();
+
                     free(sid_buffer);
 
                     return NULL;
                 }
             }
             else {
-                cio_winapi_error();
+                cio_file_native_report_os_error();
+
                 free(sid_buffer);
 
                 return NULL;
@@ -883,9 +200,9 @@ static SID *perform_sid_lookup(char *account_name, SID_NAME_USE *result_sid_type
     return sid_buffer;
 }
 
-static int cio_file_lookup_entity(char *name,
-                                  void **result,
-                                  SID_NAME_USE desired_sid_type)
+static int perform_entity_lookup(char *name,
+                                 void **result,
+                                 SID_NAME_USE desired_sid_type)
 {
     SID_NAME_USE result_sid_type;
 
@@ -897,6 +214,7 @@ static int cio_file_lookup_entity(char *name,
 
     if (desired_sid_type != result_sid_type) {
         free(*result);
+
         *result = NULL;
 
         return CIO_ERROR;
@@ -905,14 +223,14 @@ static int cio_file_lookup_entity(char *name,
     return CIO_OK;
 }
 
-int cio_file_lookup_user(char *user, void **result)
+int cio_file_native_lookup_user(char *user, void **result)
 {
-    return cio_file_lookup_entity(user, result, SidTypeUser);
+    return perform_entity_lookup(user, result, SidTypeUser);
 }
 
-int cio_file_lookup_group(char *group, void **result)
+int cio_file_native_lookup_group(char *group, void **result)
 {
-    return cio_file_lookup_entity(group, result, SidTypeGroup);
+    return perform_entity_lookup(group, result, SidTypeGroup);
 }
 
 static DWORD cio_file_win_chown(char *path, SID *user, SID *group)
@@ -941,35 +259,15 @@ static DWORD cio_file_win_chown(char *path, SID *user, SID *group)
     return result;
 }
 
-static int apply_file_ownership_and_acl_settings(struct cio_ctx *ctx, char *path)
+int cio_file_native_apply_acl_and_settings(struct cio_ctx *ctx, struct cio_file *cf)
 {
-    char *connector;
-    int   result;
-    char *group;
-    char *user;
+    int result;
 
     if (ctx->processed_user != NULL) {
-        result = cio_file_win_chown(path, ctx->processed_user, ctx->processed_group);
+        result = cio_file_win_chown(cf->path, ctx->processed_user, ctx->processed_group);
 
-        if (result != CIO_OK) {
-            cio_errno();
-
-            user = ctx->options.user;
-            group = ctx->options.group;
-            connector = "with group";
-
-            if (user == NULL) {
-                user = "";
-                connector = "";
-            }
-
-            if (group == NULL) {
-                group = "";
-                connector = "";
-            }
-
-            cio_log_error(ctx, "cannot change ownership of %s to %s %s %s",
-                          path, user, connector, group);
+        if (result != ERROR_SUCCESS) {
+            cio_file_native_report_os_error();
 
             return CIO_ERROR;
         }
@@ -978,68 +276,259 @@ static int apply_file_ownership_and_acl_settings(struct cio_ctx *ctx, char *path
     return CIO_OK;
 }
 
-int cio_file_up_force(struct cio_chunk *ch)
+static int get_file_size_by_handle(struct cio_file *cf, size_t *file_size)
 {
-    struct cio_file *cf = (struct cio_file *) ch->backend;
-    int dwDesiredAccess = 0;
-    int dwCreationDisposition = 0;
-    int meta_size;
-    int64_t size;
+    LARGE_INTEGER native_file_size;
+    int           ret;
+
+    memset(&native_file_size, 0, sizeof(native_file_size));
+
+    ret = GetFileSizeEx(cf->backing_file, &native_file_size);
+
+    if (ret == 0) {
+        return CIO_ERROR;
+    }
+
+    if (file_size != NULL) {
+        *file_size = (size_t) native_file_size.QuadPart;
+    }
+
+    return CIO_OK;
+}
+
+static int get_file_size_by_path(struct cio_file *cf, size_t *file_size)
+{
+    int            ret;
+#ifdef _WIN64
+    struct _stat64 st;
+#else
+    struct _stat32 st;
+#endif
+
+#ifdef _WIN64
+        ret = _stat64(cf->path, &st);
+#else
+        ret = _stat32(cf->path, &st);
+#endif
+
+    if (ret == -1) {
+        return CIO_ERROR;
+    }
+
+    if (file_size != NULL) {
+        *file_size = st.st_size;
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_get_size(struct cio_file *cf, size_t *file_size)
+{
     int ret;
 
-    if (cio_file_is_up(ch, cf)) {
-        win32_chunk_error(ch, "[cio file] chunk is already up");
-        return -1;
+    ret = CIO_ERROR;
+
+    if (cf->backing_file != INVALID_HANDLE_VALUE) {
+        ret = get_file_size_by_handle(cf, file_size);
+    }
+
+    if (ret != CIO_OK) {
+        ret = get_file_size_by_path(cf, file_size);
+    }
+
+    return ret;
+}
+
+char *cio_file_native_compose_path(char *root_path, char *stream_name,
+                                   char *chunk_name)
+{
+    size_t psize;
+    char  *path;
+    int    ret;
+
+    /* Compose path for the file */
+    psize = strlen(root_path) +
+            strlen(stream_name) +
+            strlen(chunk_name) +
+            3;
+
+    path = malloc(psize);
+
+    if (path == NULL) {
+        cio_file_native_report_runtime_error();
+
+        return NULL;
+    }
+
+    ret = snprintf(path, psize, "%s\\%s\\%s",
+                   root_path, stream_name, chunk_name);
+
+    if (ret == -1) {
+        cio_file_native_report_runtime_error();
+
+        free(path);
+
+        return NULL;
+    }
+
+    return path;
+}
+
+int cio_file_native_filename_check(char *name)
+{
+    size_t len;
+
+    len = strlen(name);
+
+    if (len == 0) {
+        return CIO_ERROR;
+    }
+    else if (len == 1) {
+        if (name[0] == '\\' || name[0] == '.' || name[0] == '/') {
+            return CIO_ERROR;
+        }
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_open(struct cio_file *cf)
+{
+    DWORD creation_disposition;
+    DWORD desired_access;
+
+    if (cio_file_native_is_open(cf)) {
+        return CIO_OK;
     }
 
     if (cf->flags & CIO_OPEN) {
-        dwDesiredAccess = GENERIC_READ | GENERIC_WRITE;
-        dwCreationDisposition = OPEN_ALWAYS;
+        desired_access = GENERIC_READ | GENERIC_WRITE;
+        creation_disposition = OPEN_ALWAYS;
     }
     else if (cf->flags & CIO_OPEN_RD) {
-        dwDesiredAccess = GENERIC_READ;
-        dwCreationDisposition = OPEN_EXISTING;
+        desired_access = GENERIC_READ;
+        creation_disposition = OPEN_EXISTING;
+    }
+    else {
+        return CIO_ERROR;
     }
 
-    cf->h = CreateFileA(cf->path,
-                        dwDesiredAccess,
-                        FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                        NULL,
-                        dwCreationDisposition,
-                        FILE_ATTRIBUTE_NORMAL,
-                        NULL);
+    cf->backing_file = CreateFileA(cf->path,
+                                   desired_access,
+                                   FILE_SHARE_DELETE |
+                                   FILE_SHARE_READ |
+                                   FILE_SHARE_WRITE,
+                                   NULL,
+                                   creation_disposition,
+                                   FILE_ATTRIBUTE_NORMAL,
+                                   NULL);
 
-    if (cf->h == INVALID_HANDLE_VALUE) {
-        cio_winapi_error();
-        win32_chunk_error(ch, "[cio file] cannot open");
-        return -1;
+    if (cf->backing_file == INVALID_HANDLE_VALUE) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
     }
 
-    ret = apply_file_ownership_and_acl_settings(ch->ctx, cf->path);
-    if (ret == CIO_ERROR) {
-        CloseHandle(cf->h);
-        cf->h = INVALID_HANDLE_VALUE;
+    return CIO_OK;
+}
 
-        return -1;
+int cio_file_native_close(struct cio_file *cf)
+{
+    int result;
+
+    if (cf == NULL) {
+        return CIO_ERROR;
     }
 
-    size = get_file_size(cf->h);
-    if (size < 0) {
-        win32_chunk_error(ch, "[cio file] cannot get file size");
-        return -1;
-    }
-    else if (size == 0) {
-        return init_chunk(ch);
-    }
+    if (cio_file_native_is_open(cf)) {
+        result = CloseHandle(cf->backing_file);
 
-    meta_size = read_meta_size(ch);
-    if (meta_size < 0) {
-        win32_chunk_error(ch, "[cio file] cannot read meta size");
-        return -1;
+        if (result == 0) {
+            cio_file_native_report_os_error();
+
+            return CIO_ERROR;
+        }
+
+        cf->backing_file = INVALID_HANDLE_VALUE;
     }
 
-    cf->fs_size = size;
-    cf->data_size = size - meta_size - CIO_FILE_HEADER_MIN;
+    return CIO_OK;
+}
 
-    return 0;
+int cio_file_native_delete(struct cio_file *cf)
+{
+    int result;
+
+    result = DeleteFileA(cf->path);
+
+    if (result == 0) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_sync(struct cio_file *cf, int sync_mode)
+{
+    int result;
+
+    result = FlushViewOfFile(cf->map, cf->alloc_size);
+
+    if (result == 0) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    if (sync_mode & CIO_FULL_SYNC) {
+        result = FlushFileBuffers(cf->backing_file);
+
+        if (result == 0) {
+            cio_file_native_report_os_error();
+
+            return CIO_ERROR;
+        }
+    }
+
+    return CIO_OK;
+}
+
+int cio_file_native_resize(struct cio_file *cf, size_t new_size)
+{
+    LARGE_INTEGER movement_distance;
+    int           result;
+
+    if (!cio_file_native_is_open(cf)) {
+        return CIO_ERROR;
+    }
+
+    if (cio_file_native_is_mapped(cf)) {
+        return CIO_ERROR;
+    }
+
+    movement_distance.QuadPart = new_size;
+
+    result = SetFilePointerEx(cf->backing_file,
+                              movement_distance,
+                              NULL, FILE_BEGIN);
+
+    if (result == 0) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    result = SetEndOfFile(cf->backing_file);
+
+    if (result == 0) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    cf->fs_size = new_size;
+
+    return CIO_OK;
 }

--- a/src/cio_memfs.c
+++ b/src/cio_memfs.c
@@ -33,6 +33,11 @@ struct cio_memfs *cio_memfs_open(struct cio_ctx *ctx, struct cio_stream *st,
 {
     struct cio_memfs *mf;
 
+    (void) flags;
+    (void) ctx;
+    (void) ch;
+    (void) st;
+
     mf = calloc(1, sizeof(struct cio_memfs));
     if (!mf) {
         cio_errno();
@@ -134,12 +139,14 @@ void cio_memfs_scan_dump(struct cio_ctx *ctx, struct cio_stream *st)
     struct cio_memfs *mf;
     struct cio_chunk *ch;
 
+    (void) ctx;
+
     mk_list_foreach(head, &st->chunks) {
         ch = mk_list_entry(head, struct cio_chunk, _head);
         mf = ch->backend;
 
         snprintf(tmp, sizeof(tmp) -1, "%s/%s", ch->st->name, ch->name);
         printf("        %-60s", tmp);
-        printf("meta_len=%i, data_size=%lu\n", mf->meta_len, mf->buf_len);
+        printf("meta_len=%i, data_size=%zu\n", mf->meta_len, mf->buf_len);
     }
 }

--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -53,7 +53,12 @@ int cio_os_isdir(const char *dir)
 int cio_os_mkpath(const char *dir, mode_t mode)
 {
     struct stat st;
-    char *dup_dir = NULL;
+
+#ifdef _WIN32
+    char path[MAX_PATH];
+#else
+    char *dup_dir;
+#endif
 
     if (!dir) {
         errno = EINVAL;
@@ -70,7 +75,7 @@ int cio_os_mkpath(const char *dir, mode_t mode)
     }
 
 #ifdef _WIN32
-    char path[MAX_PATH];
+    (void) mode;
 
     if (_fullpath(path, dir, MAX_PATH) == NULL) {
         return 1;

--- a/src/win32/dirent.c
+++ b/src/win32/dirent.c
@@ -38,7 +38,7 @@ struct CIO_WIN32_DIR {
 /*
  * Guess POSIX flle type from Win32 file attributes.
  */
-static int get_filetype(int dwFileAttributes)
+static unsigned char get_filetype(int dwFileAttributes)
 {
     if (dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
         return DT_DIR;
@@ -46,6 +46,7 @@ static int get_filetype(int dwFileAttributes)
     else if (dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
         return DT_LNK;
     }
+
     return DT_REG;
 }
 
@@ -55,8 +56,8 @@ static int get_filetype(int dwFileAttributes)
 static char *create_pattern(const char *path)
 {
     char *buf;
-    int len = strlen(path);
-    int buflen = len + 3;
+    size_t len = strlen(path);
+    size_t buflen = len + 3;
 
     buf = malloc(buflen);
     if (buf == NULL) {


### PR DESCRIPTION
These are the key aspects of this PR : 

win32: Implemented a new mapping based system
win32: Refactored the whole module so it only implements a set of primitives used by the file layer
unix: Added a new unix specific file backend that implements a set of standard primitives used by the file layer
utils: Added a recursive deletion function for windows (used by test cases)

Additionally the innermost error type previously reported directly through `cio_errno` has been separated into `cio_file_report_runtime_error` and `cio_file_report_os_error` which report either the `errno` related error for libc issues and the windows specific error (`GetLastError`) for API issues.

Functionality wise this is complete but more test cases should be added before merging in order to ensure that there are no breaking changes or bugs introduced since the footprint is pretty large and many inner functions have had their result protocol changed (in favor of using the standard error codes which we may or may not want to specialize further).
  