### PR TITLE
os: Support cio_os_mkpath correctly on macOS

### DIFF
--- a/src/cio_os.c
+++ b/src/cio_os.c
@@ -57,6 +57,10 @@ int cio_os_mkpath(const char *dir, mode_t mode)
 #ifdef _WIN32
     char path[MAX_PATH];
 #else
+# ifdef __APPLE__
+    char *parent_dir = NULL;
+    char *path = NULL;
+# endif
     char *dup_dir;
 #endif
 
@@ -85,6 +89,39 @@ int cio_os_mkpath(const char *dir, mode_t mode)
         return 1;
     }
     return 0;
+#elif __APPLE__
+    dup_dir = strdup(dir);
+    if (!dup_dir) {
+        return -1;
+    }
+
+    /* macOS's dirname(3) should return current directory when slash
+     * charachter is not included in passed string.
+     * And note that macOS's dirname(3) does not modify passed string.
+     */
+    parent_dir = dirname(dup_dir);
+    if (stat(parent_dir, &st) == 0 && strncmp(parent_dir, ".", 1)) {
+        if (S_ISDIR (st.st_mode)) {
+            mkdir(dup_dir, mode);
+            free(dup_dir);
+            return 0;
+        }
+    }
+
+    /* Create directories straightforward except for the last one hierarchy. */
+    for (path = strchr(dup_dir + 1, '/'); path; path = strchr(path + 1, '/')) {
+        *path = '\0';
+        if (mkdir(dup_dir, mode) == -1) {
+            if (errno != EEXIST) {
+                *path = '/';
+                return -1;
+            }
+        }
+        *path = '/';
+    }
+
+    free(dup_dir);
+    return mkdir(dir, mode);
 #else
     dup_dir = strdup(dir);
     if (!dup_dir) {


### PR DESCRIPTION
With this fix, out_s3 plugin on macOS starts to create multiparts request bodies correctly.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>