### PR TITLE
build: Generate cio_info.h and cio_version.h in source dir's include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,12 +93,12 @@ endif()
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/chunkio/cio_info.h.in"
-  "${PROJECT_BINARY_DIR}/include/chunkio/cio_info.h"
+  "${PROJECT_SOURCE_DIR}/include/chunkio/cio_info.h"
   )
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/chunkio/cio_version.h.in"
-  "${PROJECT_BINARY_DIR}/include/chunkio/cio_version.h"
+  "${PROJECT_SOURCE_DIR}/include/chunkio/cio_version.h"
   )
 
 include_directories(


### PR DESCRIPTION
Generating these headers into PROJECT_BINARY_DIR may point the different locations when bundling this library.

Then, it will be failed to built in fluent-bit:

```log
[ 20%] Building C object lib/chunkio/src/CMakeFiles/chunkio-static.dir/cio_os.c.o
<command-line>:0:0: warning: "__FILENAME__" redefined
<command-line>:0:0: note: this is the location of the previous definition
In file included from /home/runner/work/fluent-bit/fluent-bit/lib/chunkio/src/cio_os.c:28:0:
/home/runner/work/fluent-bit/fluent-bit/lib/chunkio/include/chunkio/chunkio_compat.h:23:10: fatal error: chunkio/cio_info.h: No such file or directory
 #include <chunkio/cio_info.h>
          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [lib/chunkio/src/CMakeFiles/chunkio-static.dir/cio_os.c.o] Error 1
lib/chunkio/src/CMakeFiles/chunkio-static.dir/build.make:75: recipe for target 'lib/chunkio/src/CMakeFiles/chunkio-static.dir/cio_os.c.o' failed
make[1]: *** [lib/chunkio/src/CMakeFiles/chunkio-static.dir/all] Error 2
```

ref: https://github.com/fluent/fluent-bit/runs/8251239285?check_suite_focus=true#step:5:1171

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>