### PR TITLE
corrupted chunk discard patch port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(chunk-io)
 
 set(CIO_VERSION_MAJOR  1)
-set(CIO_VERSION_MINOR  3)
+set(CIO_VERSION_MINOR  4)
 set(CIO_VERSION_PATCH  0)
 set(CIO_VERSION_STR "${CIO_VERSION_MAJOR}.${CIO_VERSION_MINOR}.${CIO_VERSION_PATCH}")
 

--- a/include/chunkio/chunkio.h
+++ b/include/chunkio/chunkio.h
@@ -38,11 +38,12 @@
 #define CIO_STORE_MEM       1
 
 /* flags */
-#define CIO_OPEN            1         /* open/create file reference */
-#define CIO_OPEN_RW         CIO_OPEN  /* new name for read/write mode */
-#define CIO_OPEN_RD         2         /* open and read/mmap content if exists */
-#define CIO_CHECKSUM        4         /* enable checksum verification (crc32) */
-#define CIO_FULL_SYNC       8         /* force sync to fs through MAP_SYNC */
+#define CIO_OPEN                 1         /* open/create file reference */
+#define CIO_OPEN_RW              CIO_OPEN  /* new name for read/write mode */
+#define CIO_OPEN_RD              2         /* open and read/mmap content if exists */
+#define CIO_CHECKSUM             4         /* enable checksum verification (crc32) */
+#define CIO_FULL_SYNC            8         /* force sync to fs through MAP_SYNC */
+#define CIO_DELETE_IRRECOVERABLE 16        /* delete irrecoverable chunks from disk */
 
 /* Return status */
 #define CIO_CORRUPTED      -3         /* Indicate that a chunk is corrupted */
@@ -92,6 +93,12 @@ struct cio_ctx {
 
     /* streams */
     struct mk_list streams;
+
+    /* errors */
+    int last_chunk_error; /* this field is necessary to discard irrecoverable
+                           * chunks in cio_scan_stream_files, it's not the
+                           * best approach but the only at the moment.
+                           */
 };
 
 #include <chunkio/cio_stream.h>

--- a/include/chunkio/cio_chunk.h
+++ b/include/chunkio/cio_chunk.h
@@ -54,6 +54,7 @@ struct cio_chunk *cio_chunk_open(struct cio_ctx *ctx, struct cio_stream *st,
                                  const char *name, int flags, size_t size,
                                  int *err);
 void cio_chunk_close(struct cio_chunk *ch, int delete);
+int cio_chunk_delete(struct cio_ctx *ctx, struct cio_stream *st, const char *name);
 int cio_chunk_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_chunk_write_at(struct cio_chunk *ch, off_t offset,
                        const void *buf, size_t count);

--- a/include/chunkio/cio_error.h
+++ b/include/chunkio/cio_error.h
@@ -26,9 +26,10 @@
 /*
  * Error status (do not confuse with return statuses!)
  */
-#define CIO_ERR_BAD_CHECKSUM -10      /* Chunk has a bad checksum */
-#define CIO_ERR_BAD_LAYOUT   -11      /* Bad magic bytes or general layout */
-#define CIO_ERR_PERMISSION   -12      /* Permission error */
+#define CIO_ERR_BAD_CHECKSUM  -10      /* Chunk has a bad checksum */
+#define CIO_ERR_BAD_LAYOUT    -11      /* Bad magic bytes or general layout */
+#define CIO_ERR_PERMISSION    -12      /* Permission error */
+#define CIO_ERR_BAD_FILE_SIZE -13      /* Chunk has a bad file size */
 
 char *cio_error_get_str(struct cio_chunk *ch);
 int cio_error_get(struct cio_chunk *ch);

--- a/include/chunkio/cio_file.h
+++ b/include/chunkio/cio_file.h
@@ -57,6 +57,7 @@ struct cio_file *cio_file_open(struct cio_ctx *ctx,
                                size_t size,
                                int *err);
 void cio_file_close(struct cio_chunk *ch, int delete);
+int cio_file_delete(struct cio_ctx *ctx, struct cio_stream *st, const char *name);
 int cio_file_write(struct cio_chunk *ch, const void *buf, size_t count);
 int cio_file_write_metadata(struct cio_chunk *ch, char *buf, size_t size);
 int cio_file_sync(struct cio_chunk *ch);

--- a/include/chunkio/cio_file_native.h
+++ b/include/chunkio/cio_file_native.h
@@ -49,6 +49,7 @@ int cio_file_native_filename_check(char *name);
 int cio_file_native_open(struct cio_file *cf);
 int cio_file_native_close(struct cio_file *cf);
 int cio_file_native_delete(struct cio_file *cf);
+int cio_file_native_delete_by_path(const char *path);
 int cio_file_native_sync(struct cio_file *cf, int sync_mode);
 int cio_file_native_resize(struct cio_file *cf, size_t new_size);
 

--- a/src/cio_chunk.c
+++ b/src/cio_chunk.c
@@ -137,6 +137,46 @@ void cio_chunk_close(struct cio_chunk *ch, int delete)
     cio_chunk_counter_total_sub(ctx);
 }
 
+int cio_chunk_delete(struct cio_ctx *ctx, struct cio_stream *st, const char *name)
+{
+    int result;
+
+    if (st == NULL) {
+        cio_log_error(ctx, "[cio chunk] invalid stream");
+
+        return CIO_ERROR;
+    }
+
+    if (name == NULL) {
+        cio_log_error(ctx, "[cio chunk] invalid file name");
+
+        return CIO_ERROR;
+    }
+
+    if (strlen(name) == 0) {
+        cio_log_error(ctx, "[cio chunk] invalid file name");
+
+        return CIO_ERROR;
+    }
+
+#ifndef CIO_HAVE_BACKEND_FILESYSTEM
+    if (st->type == CIO_STORE_FS) {
+        cio_log_error(ctx, "[cio chunk] file system backend not supported");
+
+        return CIO_ERROR;
+    }
+#endif
+
+    if (st->type == CIO_STORE_FS) {
+        result = cio_file_delete(ctx, st, name);
+    }
+    else {
+        result = CIO_ERROR;
+    }
+
+    return result;
+}
+
 /*
  * Write at a specific offset of the content area. Offset must be >= 0 and
  * less than current data length.

--- a/src/cio_error.c
+++ b/src/cio_error.c
@@ -46,6 +46,10 @@ int cio_error_get(struct cio_chunk *ch)
 void cio_error_set(struct cio_chunk *ch, int status)
 {
     ch->error_n = status;
+
+    if (ch->ctx != NULL) {
+        ch->ctx->last_chunk_error = status;
+    }
 }
 
 /* Reset the error number in a chunk */

--- a/src/cio_file_unix.c
+++ b/src/cio_file_unix.c
@@ -438,6 +438,21 @@ int cio_file_native_close(struct cio_file *cf)
     return CIO_OK;
 }
 
+int cio_file_native_delete_by_path(const char *path)
+{
+    int result;
+
+    result = unlink(path);
+
+    if (result == -1) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    return CIO_OK;
+}
+
 int cio_file_native_delete(struct cio_file *cf)
 {
     int result;

--- a/src/cio_file_win32.c
+++ b/src/cio_file_win32.c
@@ -455,6 +455,21 @@ int cio_file_native_close(struct cio_file *cf)
     return CIO_OK;
 }
 
+int cio_file_native_delete_by_path(const char *path)
+{
+    int result;
+
+    result = DeleteFileA(path);
+
+    if (result == 0) {
+        cio_file_native_report_os_error();
+
+        return CIO_ERROR;
+    }
+
+    return CIO_OK;
+}
+
 int cio_file_native_delete(struct cio_file *cf)
 {
     int result;


### PR DESCRIPTION
This PR adds the `CIO_DELETE_IRRECOVERABLE` flag and its dependencies which is used by fluent-bit to delete corrupted chunks that are deemed irrecoverable when they are found.

The two situations upon which a chunk is deemed irrecoverable are magic number corruption and file truncation.